### PR TITLE
Don't catch DataErrors

### DIFF
--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -1,6 +1,6 @@
 import flask
 from flask.views import MethodView
-from sqlalchemy.exc import DataError, IntegrityError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.exceptions import NotFound
 
@@ -175,8 +175,6 @@ class ModelView(ApiView):
                 return item
 
             raise
-        except DataError:
-            raise ApiError(400, {'code': 'invalid_id'})
 
         return item
 
@@ -216,8 +214,6 @@ class ModelView(ApiView):
             self.session.commit()
         except IntegrityError:
             raise ApiError(409, {'code': 'invalid_data.conflict'})
-        except DataError:
-            raise ApiError(422, {'code': 'invalid_data'})
 
     def make_item_response(self, item, *args):
         data_out = self.serialize(item)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py{27,35}-{base,jwt}
 [testenv]
 deps =
     flake8
-    mock
     pytest
     pytest-cov
 


### PR DESCRIPTION
These are due to e.g. type errors that are better handled by the schema.