### PR TITLE
add apispec plugin

### DIFF
--- a/flask_resty/filtering.py
+++ b/flask_resty/filtering.py
@@ -105,3 +105,7 @@ class Filtering(object):
                 raise e.update({'source': {'parameter': arg_name}})
 
         return query
+
+    def spec_declaration(self, path, spec, **kwargs):
+        for arg_name, filter_field in self._filter_fields.items():
+            path['get'].add_parameter(name=arg_name)

--- a/flask_resty/sorting.py
+++ b/flask_resty/sorting.py
@@ -71,3 +71,9 @@ class Sorting(SortingBase):
             })
 
         return super(Sorting, self).get_column(view, field_name)
+
+    def spec_declaration(self, path, spec, **kwargs):
+        path['get'].add_parameter(
+            name='sort',
+            type='string',
+            description='field to sort by')

--- a/flask_resty/spec/__init__.py
+++ b/flask_resty/spec/__init__.py
@@ -1,0 +1,9 @@
+# flake8: noqa
+
+"""Flask-Resty plugin for apispec. Allows passing a Flask-Resty
+`view` to `APISpec.add_path <apispec.APISpec.add_path>`
+"""
+
+from .plugin import setup, schema_path_helper
+from .declaration import *
+from .utils import ref, flask_path_to_swagger, get_marshmallow_schema_name

--- a/flask_resty/spec/declaration.py
+++ b/flask_resty/spec/declaration.py
@@ -1,0 +1,94 @@
+from flask.views import http_method_funcs
+
+from .utils import get_marshmallow_schema_name, ref
+
+
+class ApiViewDeclaration(object):
+    """Simple Declaration for ApiView Classes
+    :param many: whether or not this view describes a list or a single instance
+    :param tag: whether or not the schema name should be added as a tag"""
+
+    def __init__(self, many=False, tag=True, **kwargs):
+        self.many = many
+        self.tag = tag
+
+        invalid_kwargs = list(set(kwargs.keys()) - http_method_funcs)
+        if invalid_kwargs:
+            raise TypeError(
+                'invalid keyword argument "{}"'.format(invalid_kwargs[0]))
+
+        self.overrides = kwargs
+
+    def __call__(self, view, path, spec):
+        view_methods = set(view.__dict__.keys()) \
+            .intersection(http_method_funcs)
+
+        for method in view_methods:
+            operation = path[method]  # triggers the operation generation
+            if getattr(view, method).__doc__:
+                # add docstring as description
+                operation['description'] = getattr(view, method).__doc__
+
+        if view.schema:
+            self.declare_schema(view, view_methods, path, spec)
+
+        for method in view_methods.intersection(self.overrides.keys()):
+            for code, response in self.overrides[method].items():
+                path[method].declare_response(code, **response)
+
+    def declare_schema(self, view, view_methods, path, spec):
+        schema = get_marshmallow_schema_name(spec, type(view.schema))
+        schema_ref = ref(schema)
+
+        if 'get' in view_methods:
+            if not self.many:
+                data = schema_ref
+            else:
+                data = {
+                    'type': 'array',
+                    'items': schema_ref
+                }
+            path['get'].add_property_to_response(prop_name='data', **data)
+
+        if 'post' in view_methods:
+            path['post'].add_parameter('body',
+                                       name='body',
+                                       required=True,
+                                       schema=schema_ref)
+            path['post'].declare_response(201)
+
+        if 'put' in view_methods:
+            path['put'].add_parameter('body',
+                                      name='body',
+                                      required=True,
+                                      schema=schema_ref)
+            path['put'].declare_response(204)
+
+        if 'patch' in view_methods:
+            path['patch'].add_parameter('body',
+                                        name='body',
+                                        required=True,
+                                        schema=schema_ref)
+            path['patch'].add_property_to_response(prop_name='data',
+                                                   **schema_ref)
+
+        if 'delete' in view_methods:
+            path['delete'].declare_response(204)
+
+        if self.tag:
+            for method in view_methods:
+                path[method].add_tag(schema)
+
+
+class ModelViewDeclaration(ApiViewDeclaration):
+    """Declaration for Views that specify a model"""
+
+    def __call__(self, view, path, spec):
+        super(ModelViewDeclaration, self)\
+            .__call__(view, path, spec)
+
+        for item in (view.pagination, view.filtering, view.sorting):
+            try:
+                item.spec_declaration(path, spec)
+            except AttributeError:
+                pass

--- a/flask_resty/spec/operation.py
+++ b/flask_resty/spec/operation.py
@@ -1,0 +1,44 @@
+class Operation(dict):
+    """Exposes some utility methods to compose a swagger operation
+    https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#operation-object
+    """
+
+    def __init__(self):
+        super(Operation, self).__init__({
+            'responses': {},
+            'parameters': []
+        })
+
+    def add_parameter(self, location='query', **kwargs):
+        """Adds a new parameter to the request
+        :param location: the 'in' field of the parameter (e.g: 'query',
+            'body', 'path')
+        """
+        kwargs.setdefault('in', location)
+        if kwargs['in'] != 'body':
+            kwargs.setdefault('type', 'string')
+        self['parameters'].append(kwargs)
+        pass
+
+    def add_property_to_response(self, code='200', prop_name='data', **kwargs):
+        """Add a property (http://json-schema.org/latest/json-schema-validation.html#anchor64) # noqa
+        to the schema of the response identified by the code"""
+        self['responses']\
+            .setdefault(str(code), self._new_operation())\
+            .setdefault('schema', {'type': 'object'})\
+            .setdefault('properties', {})\
+            .setdefault(prop_name, {})\
+            .update(**kwargs)
+
+    def declare_response(self, code='200', **kwargs):
+        """Declare a response for the specified code
+        https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#responseObject # noqa"""
+        self['responses'][str(code)] = self._new_operation(**kwargs)
+
+    def add_tag(self, tag):
+        """Add a tag to the operation"""
+        self.setdefault('tags', []).append(tag)
+
+    def _new_operation(self, **kwargs):
+        kwargs.setdefault('description', '')
+        return dict(kwargs)

--- a/flask_resty/spec/plugin.py
+++ b/flask_resty/spec/plugin.py
@@ -1,0 +1,45 @@
+from collections import defaultdict
+
+from flask import current_app
+
+from .operation import Operation
+from .utils import flask_path_to_swagger, get_state
+
+rules = {}
+
+
+def schema_path_helper(spec, path, view, **kwargs):
+    """Path helper that uses resty views
+    :param view: an `ApiView` object
+    """
+
+    resource = get_state(current_app).views[view]
+    rule = rules[resource.rule]
+
+    operations = defaultdict(Operation)
+    view_instance = view()
+    view_instance.spec_declaration(view, operations, spec)
+
+    # add path arguments
+    parameters = []
+    for arg in rule.arguments:
+        parameters.append({
+            'name': arg,
+            'in': 'path',
+            'required': True,
+            'type': 'string',
+        })
+    if parameters:
+        path['parameters'] = parameters
+
+    path.path = flask_path_to_swagger(resource.rule)
+    path.operations = dict(**operations)
+
+
+def setup(spec):
+    """Setup for the marshmallow plugin."""
+    spec.register_path_helper(schema_path_helper)
+    global rules
+    rules = {
+        rule.rule: rule for rule in current_app.url_map.iter_rules()
+    }

--- a/flask_resty/spec/utils.py
+++ b/flask_resty/spec/utils.py
@@ -1,0 +1,34 @@
+import re
+
+RE_SWAGGER_URL = re.compile(r'<(?:[^:<>]+:)?([^<>]+)>')
+MARSHMALLOW_PLUGIN_NAME = 'apispec.ext.marshmallow'
+RESTY_PLUGIN_NAME = 'resty'
+
+
+def ref(schema_name, path='definitions'):
+    """Generate a ref object"""
+    return {'$ref': '#/{}/{}'.format(path, schema_name)}
+
+
+def flask_path_to_swagger(path):
+    """Convert a Flask URL rule to a Swagger-compliant path.
+    :param str path: Flask path template.
+    """
+    return RE_SWAGGER_URL.sub(r'{\1}', path)
+
+
+def get_marshmallow_schema_name(spec, schema):
+    """Bridge to the marshmallow plugin to get the
+    schema name. If the schema doesn't exist, create one"""
+    try:
+        return spec.plugins[MARSHMALLOW_PLUGIN_NAME]['refs'][schema]
+    except KeyError:
+        spec.definition(schema.__name__, schema=schema)
+        return schema.__name__
+
+
+def get_state(app):
+    """Gets the flask-resty state for the application"""
+    assert RESTY_PLUGIN_NAME in app.extensions, \
+        'flask-resty was not registered to the current application'
+    return app.extensions[RESTY_PLUGIN_NAME]

--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -9,6 +9,7 @@ from .authorization import NoOpAuthorization
 from .exceptions import ApiError
 from . import meta
 from . import utils
+from .spec import ApiViewDeclaration, ModelViewDeclaration
 
 # -----------------------------------------------------------------------------
 
@@ -18,6 +19,8 @@ class ApiView(MethodView):
 
     authentication = NoOpAuthentication()
     authorization = NoOpAuthorization()
+
+    spec_declaration = ApiViewDeclaration()
 
     def dispatch_request(self, *args, **kwargs):
         self.authentication.authenticate_request()
@@ -117,6 +120,8 @@ class ModelView(ApiView):
     pagination = None
 
     related = None
+
+    spec_declaration = ModelViewDeclaration()
 
     @property
     def session(self):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import Command, setup
+from setuptools import Command, setup, find_packages
 import subprocess
 
 # -----------------------------------------------------------------------------
@@ -44,7 +44,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ),
     keywords='rest flask',
-    packages=('flask_resty',),
+    packages=find_packages(exclude='tests'),
     install_requires=(
         'Flask >= 0.10',
         'Flask-SQLAlchemy >= 1.0',

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1,0 +1,313 @@
+import operator
+
+from apispec import APISpec
+from marshmallow import fields, Schema
+import pytest
+
+from flask_resty import (
+    Api, Filtering, GenericModelView, PagePagination, Sorting,
+    IdCursorPagination,
+)
+from flask_resty.spec import ModelViewDeclaration
+
+
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def schemas(app):
+    class FooSchema(Schema):
+        id = fields.Integer(as_string=True)
+        name = fields.String(required=True)
+        color = fields.String()
+
+    return {
+        'foo': FooSchema
+    }
+
+
+@pytest.fixture(autouse=True)
+def routes(app, schemas):
+    class FooView(GenericModelView):
+        schema = schemas['foo']()
+
+        def get(self, id):
+            pass
+
+        def put(self, id):
+            pass
+
+        def delete(self, id):
+            pass
+
+        def patch(self):
+            pass
+
+    class FooListView(GenericModelView):
+        schema = schemas['foo']()
+        pagination = PagePagination(2)
+        sorting = Sorting('name', 'color')
+        spec_declaration = ModelViewDeclaration(many=True)
+
+        filtering = Filtering(
+            color=operator.eq,
+        )
+
+        def get(self):
+            pass
+
+        def post(self):
+            """test the docstring"""
+            pass
+
+    class BarView(GenericModelView):
+        pagination = IdCursorPagination(2)
+
+        spec_declaration = ModelViewDeclaration(
+            post={'204': {'description': 'request the creation of a new bar'}},
+            get={'200': {}}
+        )
+
+        def post(self):
+            pass
+
+        def get(self):
+            pass
+
+        def put(self):
+            """put a bar"""
+            pass
+
+    api = Api(app)
+    api.add_resource('/foos', FooListView, FooView)
+    api.add_resource('/bars', BarView)
+
+    return {
+        'foo': FooView,
+        'fooList': FooListView,
+        'bar': BarView,
+    }
+
+
+@pytest.fixture(autouse=True)
+def ctx(app):
+    ctx = app.test_request_context()
+    ctx.push()
+
+
+@pytest.fixture()
+def spec(app, schemas, routes):
+    spec = APISpec(
+        title='test api',
+        version='0.1.0',
+        plugins=('apispec.ext.marshmallow', 'flask_resty.spec'))
+
+    spec.definition('Foo', schema=schemas['foo'])
+
+    spec.add_path(view=routes['fooList'])
+    spec.add_path(view=routes['foo'])
+    spec.add_path(view=routes['bar'])
+
+    return spec.to_dict()
+
+# -----------------------------------------------------------------------------
+
+
+def test_definition_autogeneration(app, routes):
+    spec = APISpec(
+        title='test api',
+        version='0.1.0',
+        plugins=('apispec.ext.marshmallow', 'flask_resty.spec'))
+
+    spec.add_path(view=routes['fooList'])
+
+    assert 'FooSchema' in spec.to_dict()['definitions']
+
+
+def test_tagging(app, routes):
+    spec = APISpec(
+        title='test api',
+        version='0.1.0',
+        plugins=('apispec.ext.marshmallow', 'flask_resty.spec'))
+
+    spec.add_path(view=routes['fooList'])
+
+    assert 'FooSchema' in spec.to_dict()['paths']['/foos']['get']['tags']
+
+
+def test_invalid_kwargs():
+    with pytest.raises(TypeError) as excinfo:
+        ModelViewDeclaration(putt=123)
+    assert 'invalid keyword argument "putt"' == str(excinfo.value)
+
+
+def test_schema_definitions(spec):
+    assert spec['definitions']['Foo'] == {
+        'required': ['name'],
+        'properties': {
+            'id': {'type': 'integer', 'format': 'int32'},
+            'name': {'type': 'string'},
+            'color': {'type': 'string'},
+        }
+    }
+
+
+def test_paths(spec):
+    assert '/foos' in spec['paths']
+    assert '/foos/{id}' in spec['paths']
+    assert '/bars' in spec['paths']
+
+
+def test_get_response(spec):
+    foo_get = spec['paths']['/foos/{id}']['get']
+    assert foo_get['responses'] == {
+        '200': {
+            'description': '',
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'data': {'$ref': '#/definitions/Foo'}
+                }
+            }
+        }
+    }
+
+
+def test_get_list_response(spec):
+    foos_get = spec['paths']['/foos']['get']
+    assert foos_get['responses']['200']['schema']['properties']['data'] == {
+        'type': 'array',
+        'items': {'$ref': '#/definitions/Foo'}
+    }
+
+
+def test_get_pagination_meta(spec):
+    foos_get = spec['paths']['/foos']['get']
+    assert foos_get['responses']['200']['schema']['properties']['meta'] == {
+        'type': 'object',
+        'properties': {
+            'has_next_page': {'type': 'boolean'}
+        }
+    }
+
+
+def test_post_response(spec):
+    foos_get = spec['paths']['/foos']['post']
+    assert foos_get['responses'] == {
+        '201': {'description': ''}
+    }
+
+
+def test_put_response(spec):
+    foo_put = spec['paths']['/foos/{id}']['put']
+    assert foo_put['responses'] == {
+        '204': {'description': ''}
+    }
+
+
+def test_delete_response(spec):
+    foo_delete = spec['paths']['/foos/{id}']['delete']
+    assert foo_delete['responses'] == {
+        '204': {'description': ''}
+    }
+
+
+def test_only_requested_methods(spec):
+    assert set(spec['paths']['/foos'].keys()) == {'post', 'get'}
+    assert set(spec['paths']['/foos/{id}'].keys()) == \
+        {'put', 'patch', 'delete', 'parameters', 'get'}
+    assert set(spec['paths']['/bars'].keys()) == {'put', 'post', 'get'}
+
+
+def test_path_params(spec):
+    query_param = {
+        'in': 'path',
+        'required': True,
+        'type': 'string',
+        'name': 'id',
+    }
+    assert query_param in spec['paths']['/foos/{id}']['parameters']
+
+
+def test_body_params(spec):
+    foo_post = spec['paths']['/foos']['post']
+    body = {
+        'in': 'body',
+        'name': 'body',
+        'required': True,
+        'schema': {'$ref': '#/definitions/Foo'}
+    }
+    assert body in foo_post['parameters']
+
+
+def test_pagination(spec):
+    foos_get = spec['paths']['/foos']['get']
+
+    pars = [('limit', 'pagination limit'),
+            ('offset', 'pagination offset'),
+            ('page', 'page number')]
+
+    for parameter_name, description in pars:
+        parameter = {
+            'in': 'query',
+            'name': parameter_name,
+            'type': 'int',
+            'description': description,
+        }
+        assert parameter in foos_get['parameters']
+
+
+def test_sorting(spec):
+    foos_get = spec['paths']['/foos']['get']
+
+    parameter = {
+        'in': 'query',
+        'name': 'sort',
+        'type': 'string',
+        'description': 'field to sort by',
+    }
+    assert parameter in foos_get['parameters']
+
+
+def test_filters(spec):
+    foos_get = spec['paths']['/foos']['get']
+
+    parameter = {
+        'in': 'query',
+        'name': 'color',
+        'type': 'string'
+    }
+    assert parameter in foos_get['parameters']
+
+
+def test_docstring(spec):
+    foos_post = spec['paths']['/foos']['post']
+    assert foos_post['description'] == 'test the docstring'
+
+
+def test_schemaless(spec):
+    bars_post = spec['paths']['/bars']['post']
+    assert bars_post['responses'] == {
+        '204': {
+            'description': 'request the creation of a new bar'
+        }
+    }
+
+    bars_put = spec['paths']['/bars']['put']
+    assert bars_put == {
+        'responses': {},
+        'parameters': [],
+        'description': 'put a bar'
+    }
+
+
+def test_cursor_pagination(spec):
+    bars_get = spec['paths']['/bars']['get']
+
+    parameter = {
+        'in': 'query',
+        'name': 'cursor',
+        'type': 'string',
+        'description': 'pagination cursor',
+    }
+    assert parameter in bars_get['parameters']

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     flake8
     pytest
     pytest-cov
+    apispec
 
 commands =
     # Need editable install for coverage reporting.


### PR DESCRIPTION
with this pr is possible to use `flask_res.spec` as a plugin to [apispec](https://github.com/marshmallow-code/apispec) to generate swagger options.

Some remarks: I don’t know if the idea of subclassing `SpecDeclaration`
is a good way to do it. I tried to automate as many things as possible,
with the result that the end result might not always be correct. The
View can always subclass SpecDeclaration and correct any errors coming
from the view superclasses.