### PR TITLE
relax assert_value

### DIFF
--- a/flask_resty/compat.py
+++ b/flask_resty/compat.py
@@ -5,5 +5,7 @@ PY2 = int(sys.version_info[0]) == 2
 
 if PY2:
     zip_longest = itertools.izip_longest
+    String = basestring
 else:
     zip_longest = itertools.zip_longest
+    String = str

--- a/flask_resty/compat.py
+++ b/flask_resty/compat.py
@@ -5,7 +5,7 @@ PY2 = int(sys.version_info[0]) == 2
 
 if PY2:
     zip_longest = itertools.izip_longest
-    String = basestring  # noqa
+    basestring = basestring  # noqa
 else:
     zip_longest = itertools.zip_longest
-    String = str
+    basestring = (str, bytes)

--- a/flask_resty/compat.py
+++ b/flask_resty/compat.py
@@ -5,7 +5,7 @@ PY2 = int(sys.version_info[0]) == 2
 
 if PY2:
     zip_longest = itertools.izip_longest
-    String = basestring
+    String = basestring  # noqa
 else:
     zip_longest = itertools.zip_longest
     String = str

--- a/flask_resty/testing.py
+++ b/flask_resty/testing.py
@@ -28,12 +28,13 @@ def get_meta(response):
 
 
 def assert_value(actual, expected):
-    if isinstance(expected, dict):
+    if isinstance(expected, Mapping):
         assert isinstance(actual, Mapping)
         for k, v in expected.items():
             assert_value(actual.get(k, None), v)
-    elif isinstance(expected, Sequence) \
-            and not isinstance(expected, basestring):
+    elif isinstance(expected, basestring):
+        assert actual == expected
+    elif isinstance(expected, Sequence):
         assert isinstance(actual, Sequence)
         for a, e in zip_longest(actual, expected):
             assert_value(a, e)

--- a/flask_resty/testing.py
+++ b/flask_resty/testing.py
@@ -1,3 +1,4 @@
+from collections import Mapping, Sequence
 import json
 
 from .compat import zip_longest
@@ -28,9 +29,11 @@ def get_meta(response):
 
 def assert_value(actual, expected):
     if isinstance(expected, dict):
+        assert isinstance(actual, Mapping)
         for k, v in expected.items():
             assert_value(actual.get(k, None), v)
-    elif isinstance(expected, list):
+    elif isinstance(expected, Sequence) and not isinstance(expected, str):
+        assert isinstance(actual, Sequence)
         for a, e in zip_longest(actual, expected):
             assert_value(a, e)
     elif isinstance(expected, float):

--- a/flask_resty/testing.py
+++ b/flask_resty/testing.py
@@ -1,7 +1,7 @@
 from collections import Mapping, Sequence
 import json
 
-from .compat import String, zip_longest
+from .compat import basestring, zip_longest
 
 # -----------------------------------------------------------------------------
 
@@ -32,7 +32,8 @@ def assert_value(actual, expected):
         assert isinstance(actual, Mapping)
         for k, v in expected.items():
             assert_value(actual.get(k, None), v)
-    elif isinstance(expected, Sequence) and not isinstance(expected, String):
+    elif isinstance(expected, Sequence) \
+            and not isinstance(expected, basestring):
         assert isinstance(actual, Sequence)
         for a, e in zip_longest(actual, expected):
             assert_value(a, e)

--- a/flask_resty/testing.py
+++ b/flask_resty/testing.py
@@ -28,11 +28,9 @@ def get_meta(response):
 
 def assert_value(actual, expected):
     if isinstance(expected, dict):
-        assert isinstance(actual, dict)
         for k, v in expected.items():
             assert_value(actual.get(k, None), v)
     elif isinstance(expected, list):
-        assert isinstance(actual, list)
         for a, e in zip_longest(actual, expected):
             assert_value(a, e)
     elif isinstance(expected, float):

--- a/flask_resty/testing.py
+++ b/flask_resty/testing.py
@@ -1,7 +1,7 @@
 from collections import Mapping, Sequence
 import json
 
-from .compat import zip_longest
+from .compat import String, zip_longest
 
 # -----------------------------------------------------------------------------
 
@@ -32,7 +32,7 @@ def assert_value(actual, expected):
         assert isinstance(actual, Mapping)
         for k, v in expected.items():
             assert_value(actual.get(k, None), v)
-    elif isinstance(expected, Sequence) and not isinstance(expected, str):
+    elif isinstance(expected, Sequence) and not isinstance(expected, String):
         assert isinstance(actual, Sequence)
         for a, e in zip_longest(actual, expected):
             assert_value(a, e)


### PR DESCRIPTION
Either we remove them, or we come up with something more generic. probably we don't need them at all. eg If `actual` is not dictionary-ish enough to have `.get`, it will fail anyway