### PR TITLE
Expunge instances with unauthorized changes

### DIFF
--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -268,7 +268,11 @@ class ModelView(ApiView):
     def add_item(self, item):
         self.session.add(item)
 
-        self.authorization.authorize_save_item(item)
+        try:
+            self.authorization.authorize_save_item(item)
+        except Exception:
+            self.session.expunge(item)
+            raise
 
     def create_and_add_item(self, data):
         item = self.create_item(data)
@@ -281,7 +285,11 @@ class ModelView(ApiView):
         for key, value in data.items():
             setattr(item, key, value)
 
-        self.authorization.authorize_save_item(item)
+        try:
+            self.authorization.authorize_save_item(item)
+        except Exception:
+            self.session.expunge(item)
+            raise
 
     def delete_item(self, item):
         self.authorization.authorize_delete_item(item)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -239,6 +239,15 @@ def test_error_create_unauthorized(client):
 
 
 def test_error_update_unauthorized(client):
+    forbidden_save_response = client.patch('/widgets/1?user_id=foo', data={
+        'id': '1',
+        'owner_id': 'bar',
+        'name': "Updated",
+    })
+    assert_response(forbidden_save_response, 403, [{
+        'code': 'invalid_user',
+    }])
+
     not_found_response = client.patch('/widgets/1?user_id=bar', data={
         'id': '1',
         'owner_id': 'bar',
@@ -246,12 +255,12 @@ def test_error_update_unauthorized(client):
     })
     assert_response(not_found_response, 404)
 
-    forbidden_response = client.patch('/widgets/3?user_id=bar', data={
+    forbidden_update_response = client.patch('/widgets/3?user_id=foo', data={
         'id': '3',
-        'owner_id': 'bar',
+        'owner_id': 'foo',
         'name': "Updated",
     })
-    assert_response(forbidden_response, 403, [{
+    assert_response(forbidden_update_response, 403, [{
         'code': 'invalid_user',
     }])
 


### PR DESCRIPTION
Just in case someone catches the exception and commits, we don't want to accidentally commit bad changes.