### PR TITLE
Revert "Use 'query' instead of 'parameter' in source"

### DIFF
--- a/flask_resty/filtering.py
+++ b/flask_resty/filtering.py
@@ -121,7 +121,7 @@ class Filtering(object):
             try:
                 query = query.filter(filter_field(view, arg_value))
             except ApiError as e:
-                raise e.update({'source': {'query': arg_name}})
+                raise e.update({'source': {'parameter': arg_name}})
 
         return query
 

--- a/flask_resty/pagination.py
+++ b/flask_resty/pagination.py
@@ -68,7 +68,7 @@ class LimitPagination(LimitPaginationBase):
         try:
             return self.parse_limit(limit)
         except ApiError as e:
-            raise e.update({'source': {'query': self.limit_arg}})
+            raise e.update({'source': {'parameter': self.limit_arg}})
 
     def parse_limit(self, limit):
         if limit is None:
@@ -114,7 +114,7 @@ class LimitOffsetPagination(LimitPagination):
         try:
             return self.parse_offset(offset)
         except ApiError as e:
-            raise e.update({'source': {'query': self.offset_arg}})
+            raise e.update({'source': {'parameter': self.offset_arg}})
 
     def parse_offset(self, offset):
         if offset is None:
@@ -154,7 +154,7 @@ class PagePagination(LimitOffsetPagination):
         try:
             return self.parse_page(page)
         except ApiError as e:
-            raise e.update({'source': {'query': self.page_arg}})
+            raise e.update({'source': {'parameter': self.page_arg}})
 
     def parse_page(self, page):
         if page is None:
@@ -212,7 +212,7 @@ class CursorPaginationBase(LimitPagination):
         try:
             return self.parse_cursor(cursor, view, field_orderings)
         except ApiError as e:
-            raise e.update({'source': {'query': self.cursor_arg}})
+            raise e.update({'source': {'parameter': self.cursor_arg}})
 
     def parse_cursor(self, cursor, view, field_orderings):
         cursor = self.decode_cursor(cursor)

--- a/flask_resty/sorting.py
+++ b/flask_resty/sorting.py
@@ -73,7 +73,7 @@ class Sorting(SortingBase):
         if field_name not in self._field_names:
             raise ApiError(400, {
                 'code': 'invalid_sort',
-                'source': {'query': self.sort_arg},
+                'source': {'parameter': self.sort_arg},
             })
 
         return super(Sorting, self).get_column(view, field_name)

--- a/flask_resty/spec/operation.py
+++ b/flask_resty/spec/operation.py
@@ -18,15 +18,16 @@ class Operation(dict):
         if kwargs['in'] != 'body':
             kwargs.setdefault('type', 'string')
         self['parameters'].append(kwargs)
+        pass
 
     def add_property_to_response(self, code='200', prop_name='data', **kwargs):
         """Add a property (http://json-schema.org/latest/json-schema-validation.html#anchor64)  # noqa: E501
         to the schema of the response identified by the code"""
-        self['responses'] \
-            .setdefault(str(code), self._new_operation()) \
-            .setdefault('schema', {'type': 'object'}) \
-            .setdefault('properties', {}) \
-            .setdefault(prop_name, {}) \
+        self['responses']\
+            .setdefault(str(code), self._new_operation())\
+            .setdefault('schema', {'type': 'object'})\
+            .setdefault('properties', {})\
+            .setdefault(prop_name, {})\
             .update(**kwargs)
 
     def declare_response(self, code='200', **kwargs):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -242,5 +242,5 @@ def test_error_invalid_field(client):
     assert_response(response, 400, [{
         'code': 'invalid_filter',
         'detail': 'Not a valid integer.',
-        'source': {'query': 'size_min'},
+        'source': {'parameter': 'size_min'},
     }])

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -466,7 +466,7 @@ def test_error_invalid_limit_type(client):
     response = client.get('/limit_offset_widgets?limit=foo')
     assert_response(response, 400, [{
         'code': 'invalid_limit',
-        'source': {'query': 'limit'},
+        'source': {'parameter': 'limit'},
     }])
 
 
@@ -474,7 +474,7 @@ def test_error_invalid_limit_value(client):
     response = client.get('/limit_offset_widgets?limit=-1')
     assert_response(response, 400, [{
         'code': 'invalid_limit',
-        'source': {'query': 'limit'},
+        'source': {'parameter': 'limit'},
     }])
 
 
@@ -482,7 +482,7 @@ def test_error_invalid_offset_type(client):
     response = client.get('/limit_offset_widgets?offset=foo')
     assert_response(response, 400, [{
         'code': 'invalid_offset',
-        'source': {'query': 'offset'},
+        'source': {'parameter': 'offset'},
     }])
 
 
@@ -490,7 +490,7 @@ def test_error_invalid_offset_value(client):
     response = client.get('/limit_offset_widgets?offset=-1')
     assert_response(response, 400, [{
         'code': 'invalid_offset',
-        'source': {'query': 'offset'},
+        'source': {'parameter': 'offset'},
     }])
 
 
@@ -498,7 +498,7 @@ def test_error_invalid_page_type(client):
     response = client.get('/page_widgets?page=foo')
     assert_response(response, 400, [{
         'code': 'invalid_page',
-        'source': {'query': 'page'},
+        'source': {'parameter': 'page'},
     }])
 
 
@@ -506,7 +506,7 @@ def test_error_invalid_page_value(client):
     response = client.get('/page_widgets?page=-1')
     assert_response(response, 400, [{
         'code': 'invalid_page',
-        'source': {'query': 'page'},
+        'source': {'parameter': 'page'},
     }])
 
 
@@ -514,7 +514,7 @@ def test_error_invalid_relay_cursor_encoding(client):
     response = client.get('/relay_cursor_widgets?cursor=_')
     assert_response(response, 400, [{
         'code': 'invalid_cursor.encoding',
-        'source': {'query': 'cursor'},
+        'source': {'parameter': 'cursor'},
     }])
 
 
@@ -522,7 +522,7 @@ def test_error_invalid_relay_cursor_length(client):
     response = client.get('/relay_cursor_widgets?cursor=MQ.MQ')
     assert_response(response, 400, [{
         'code': 'invalid_cursor.length',
-        'source': {'query': 'cursor'},
+        'source': {'parameter': 'cursor'},
     }])
 
 
@@ -531,5 +531,5 @@ def test_error_invalid_relay_cursor_field(client):
     assert_response(response, 400, [{
         'code': 'invalid_cursor',
         'detail': 'Not a valid integer.',
-        'source': {'query': 'cursor'},
+        'source': {'parameter': 'cursor'},
     }])

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -169,7 +169,7 @@ def test_error_invalid_field(client):
 
     assert_response(response, 400, [{
         'code': 'invalid_sort',
-        'source': {'query': 'sort'},
+        'source': {'parameter': 'sort'},
     }])
 
 
@@ -177,5 +177,5 @@ def test_error_empty(client):
     response = client.get('/widgets?sort=')
     assert_response(response, 400, [{
         'code': 'invalid_sort',
-        'source': {'query': 'sort'},
+        'source': {'parameter': 'sort'},
     }])


### PR DESCRIPTION
Reverts 4Catalyzer/flask-resty#127

#149 is breaking anyway so why not