### PR TITLE
Do not add in create_missing when not updating

### DIFF
--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -278,8 +278,6 @@ class ModelView(ApiView):
                     # Bypass authorizating the save if we are getting the item
                     # for update, as update_item will make that check.
                     self.session.add(item)
-                else:
-                    self.add_item(item)
             except ApiError:
                 # Raise the original not found error instead of the
                 # authorization error.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -227,7 +227,6 @@ def test_retrieve_create_missing(client, auth):
 
     assert auth['authorization'].authorize_modify_item.mock_calls == [
         call(ANY, 'create'),
-        call(ANY, 'save'),
     ]
 
 


### PR DESCRIPTION
Thinking about this more, it doesn't really make sense to do `add_item` in the `create_missing` branch. If you're doing an update, you will set `will_update_item`. If not, you're not going to save the item anyway, so adding it doesn't accomplish anything.

This also makes the permission checking more straightforward. After all, it's `create_missing`, not `create_and_add_missing`.