### PR TITLE
Track action on GenericModelView

### DIFF
--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -370,15 +370,26 @@ class ModelView(ApiView):
 
 
 class GenericModelView(ModelView):
+    def __init__(self):
+        super(GenericModelView, self).__init__()
+
+        self.action = None
+
     def list(self):
+        self.action = 'list'
+
         items = self.get_list()
         return self.make_items_response(items)
 
     def retrieve(self, id, create_missing=False):
+        self.action = 'retrieve'
+
         item = self.get_item_or_404(id, create_missing=create_missing)
         return self.make_item_response(item)
 
     def create(self, allow_client_id=False):
+        self.action = 'create'
+
         expected_id = None if allow_client_id else False
         data_in = self.get_request_data(expected_id=expected_id)
 
@@ -394,6 +405,8 @@ class GenericModelView(ModelView):
         partial=False,
         return_content=False,
     ):
+        self.action = 'update'
+
         # No need to authorize creating the missing item, as we will authorize
         # before saving to database below.
         item = self.get_item_or_404(
@@ -412,6 +425,8 @@ class GenericModelView(ModelView):
         return self.make_empty_response(item=item)
 
     def destroy(self, id):
+        self.action = 'destroy'
+
         item = self.get_item_or_404(id)
 
         self.delete_item(item)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -107,7 +107,7 @@ def test_create_no_location(app, views, client):
     })
 
 
-def test_training_slash(app, views, client):
+def test_trailing_slash(app, views, client):
     api = Api(app)
     api.add_resource(
         '/widgets/', views['widget_list'], views['widget'], id_rule='<id>/',


### PR DESCRIPTION
It's occasionally convenient to track the semantic action. This seems pretty straightforward as an implementation.