### PR TITLE
Use blinker to signal handled integrity errors

### DIFF
--- a/flask_resty/__init__.py
+++ b/flask_resty/__init__.py
@@ -29,6 +29,7 @@ from .pagination import (
     RelayCursorPagination,
 )
 from .related import Related, RelatedId
+from .signals import got_handled_integrity_error
 from .sorting import FieldSortingBase, FixedSorting, Sorting, SortingBase
 from .view import ApiView, GenericModelView, ModelView
 

--- a/flask_resty/signals.py
+++ b/flask_resty/signals.py
@@ -1,0 +1,7 @@
+import blinker
+
+# -----------------------------------------------------------------------------
+
+signals = blinker.Namespace()
+
+got_handled_integrity_error = signals.signal('got-handled-integrity-error')

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     keywords='rest flask',
     packages=find_packages(exclude=('tests',)),
     install_requires=(
+        'blinker >= 1.0',
         'Flask >= 0.10',
         'Flask-SQLAlchemy >= 1.0',
         'marshmallow >= 2.2.0',


### PR DESCRIPTION
I dunno. What do you think? This feels more semantically correct.

Sentry also lets us capture log events, but... I'm not sure. It seems better to capture an exception than a log message anyway, no?

But actually Sentry has some clever stuff to handle logging, and using a logger is more consistent with what we're doing on the JS side.

But here, the idiomatic way to scope loggers is by module, and that seems insufficiently semantically meaningful.

Thoughts?