### PR TITLE
chore: move jsonify call to make_response_body

### DIFF
--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -56,14 +56,14 @@ class ApiView(MethodView):
 
     def make_response(self, data, *args, **kwargs):
         body = self.make_response_body(data, meta.get_response_meta())
-        return self.make_raw_response(flask.jsonify(body), *args, **kwargs)
+        return self.make_raw_response(body, *args, **kwargs)
 
     def make_response_body(self, data, response_meta):
         body = {'data': data}
         if response_meta is not None:
             body['meta'] = response_meta
 
-        return body
+        return flask.jsonify(body)
 
     def make_raw_response(self, *args, **kwargs):
         response = flask.make_response(*args)


### PR DESCRIPTION
If `make_response` does not assume the content type then we can return
things that are not `application/json` without re-implementing both
`make_response` and `make_response_body`.