### PR TITLE
fix: don't apply concrete validation when validate=False

### DIFF
--- a/flask_resty/filtering.py
+++ b/flask_resty/filtering.py
@@ -165,7 +165,12 @@ class ColumnFilter(FieldFilterBase):
             # We may not want to apply the same validation for filters as we do
             # on model fields. This bypasses the irrelevant handling of missing
             # and None values, and skips the validation check.
-            return field._deserialize(value_raw, None, None)
+            try:
+                return field._deserialize(value_raw, None, None)
+            # Some concrete implementations of `_deserialize`, e.g UUID, apply
+            # additional validation that we want to ignore.
+            except ValidationError:
+                return value_raw
 
         return super(ColumnFilter, self).deserialize(field, value_raw)
 


### PR DESCRIPTION
This is useful for "search". If you'd like we could split this into two
flags: `allow_empty=<bool>` and `validate=<bool>`.