### PR TITLE
Remove sudo: from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: python
 python:
   - "2.7"
@@ -18,9 +16,7 @@ matrix:
       env: TOXENV=py-base
     - python: "3.6"
       env: TOXENV=py-base
-    - # TODO: Remove this workaround once travis-ci/travis-ci#9815 is fixed.
-      sudo: true
-      dist: xenial
+    - dist: xenial
       python: "3.7"
       env: TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test
     - python: "pypy"


### PR DESCRIPTION
Travis CI has migrated to their VM-based infrastructure,
so `sudo:` no longer has an effect.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration