### PR TITLE
chore: Minor Travis config cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,18 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-
 services:
   - postgresql
-
-env:
-  - TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test
-
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py-base
-    - python: "3.6"
-      env: TOXENV=py-base
-    - dist: xenial
-      python: "3.7"
-      env: TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test
-    - python: "pypy"
-      env: TOXENV=py-full
-    - python: "pypy3"
-      env: TOXENV=py-full
+    - { python: "2.7",   env: "TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test" }
+    - { python: "3.5",   env: "TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test" }
+    - { python: "3.6",   env: "TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test" }
+    - { python: "3.7",   env: "TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test", dist: "xenial" }
+
+    - { python: "2.7",   env: "TOXENV=py-base" }
+    - { python: "3.6",   env: "TOXENV=py-base" }
+
+    - { python: "pypy",  env: "TOXENV=py-full" }
+    - { python: "pypy3", env: "TOXENV=py-full" }
 
 cache:
   directories:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,37}-{base,full}
+envlist = py{27,35,36,37}-{base,full}
 
 [testenv]
 passenv = DATABASE_URL

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37}-{base,full}
+envlist = py{27,35,37}-{base,full}
 
 [testenv]
 passenv = DATABASE_URL


### PR DESCRIPTION
Visually align the `python` and `env` keys to
make them easier to read.