### PR TITLE
chore: Address warnings in pytest output

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ universal = 1
 
 [metadata]
 long_description = file: README.rst
+
+[tool:pytest]
+filterwarnings =
+  ignore:strict=False:marshmallow.warnings.ChangedInMarshmallow3Warning

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -368,10 +368,10 @@ def test_error_model_filter_required_missing(client):
 def test_error_missing_operator():
     ColumnFilter(operator=operator.eq)
 
-    with pytest.raises(TypeError, message="must specify operator"):
+    with pytest.raises(TypeError, match="must specify operator"):
         ColumnFilter('size')
 
-    with pytest.raises(TypeError, message="must specify operator"):
+    with pytest.raises(TypeError, match="must specify operator"):
         ColumnFilter()
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -170,7 +170,7 @@ def test_factory_pattern(app, views, client):
     api = Api()
     api.init_app(app)
 
-    with pytest.raises(AssertionError, message="no application specified"):
+    with pytest.raises(AssertionError, match="no application specified"):
         api.add_resource('/widgets', views['widget_list'])
 
     api.add_resource('/widgets', views['widget_list'], app=app)


### PR DESCRIPTION
Before:

<img width="994" alt="1 dotfiles tmuxp load -y play 2019-02-08 09-31-57" src="https://user-images.githubusercontent.com/2379650/52484472-67e13280-2b84-11e9-87c1-16acad7d1c1d.png">

After:

<img width="308" alt="1 dotfiles tmuxp load -y play 2019-02-08 09-32-40" src="https://user-images.githubusercontent.com/2379650/52484504-7e878980-2b84-11e9-8377-69e525e56995.png">
 