### PR TITLE
chore: Remove unnecessary pytest config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,3 @@ universal = 1
 
 [metadata]
 long_description = file: README.rst
-
-[tool:pytest]
-filterwarnings =
-  ignore:strict=False:marshmallow.warnings.ChangedInMarshmallow3Warning


### PR DESCRIPTION
We ended up removing the warning about ``strict=False``
in marshmallow-code/marshmallow#1136, so this
config is no longer necessary.