### PR TITLE
chore: Use xenial for all builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 services:
   - postgresql
 matrix:
@@ -6,7 +7,7 @@ matrix:
     - { python: "2.7",   env: "TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test" }
     - { python: "3.5",   env: "TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test" }
     - { python: "3.6",   env: "TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test" }
-    - { python: "3.7",   env: "TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test", dist: "xenial" }
+    - { python: "3.7",   env: "TOXENV=py-full DATABASE_URL=postgres://localhost/travis_ci_test" }
 
     - { python: "2.7",   env: "TOXENV=py-base" }
     - { python: "3.6",   env: "TOXENV=py-base" }

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
     - { python: "2.7",   env: "TOXENV=py-base" }
     - { python: "3.6",   env: "TOXENV=py-base" }
 
-    - { python: "pypy",  env: "TOXENV=py-full" }
-    - { python: "pypy3", env: "TOXENV=py-full" }
+    - { python: "pypy2.7-6.0",  env: "TOXENV=py-full" }
+    - { python: "pypy3.5-6.0", env: "TOXENV=py-full" }
 
 cache:
   directories:


### PR DESCRIPTION
xenial supports all Python versions, so no need
to special-case it for Python 3.7.