### PR TITLE
Drop pypy jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ matrix:
     - { python: "3.6",   env: "TOXENV=py-full-marshmallow3" }
     - { python: "2.7",   env: "TOXENV=py-base-marshmallow3" }
     - { python: "3.6",   env: "TOXENV=py-base-marshmallow3" }
-
-    - { python: "pypy2.7-6.0", env: "TOXENV=py-full-marshmallow2" }
-    - { python: "pypy3.5-6.0", env: "TOXENV=py-full-marshmallow2" }
-
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
...to speed up builds. We're already testing against
py27 and py35 anyway.