### PR TITLE
fix: don't test against marshmallow 3 x Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ matrix:
     - { python: "2.7",   env: "TOXENV=py-base-marshmallow2" }
     - { python: "3.6",   env: "TOXENV=py-base-marshmallow2" }
 
-    - { python: "2.7",   env: "TOXENV=py-full-marshmallow3" }
     - { python: "3.6",   env: "TOXENV=py-full-marshmallow3" }
-    - { python: "2.7",   env: "TOXENV=py-base-marshmallow3" }
     - { python: "3.6",   env: "TOXENV=py-base-marshmallow3" }
 cache:
   directories:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py{27,35,37}-{base,full}-marshmallow{2,3}
+envlist = 
+  py{27,35,37}-{base,full}-marshmallow2
+  py{35,37}-{base,full}-marshmallow3
 
 [testenv]
 passenv = DATABASE_URL


### PR DESCRIPTION
marshmallow 3 no longer supports Python 2
https://github.com/marshmallow-code/marshmallow/issues/1120