### PR TITLE
fix: Fix Flask dependency range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     keywords='rest flask',
     packages=('flask_resty',),
     install_requires=(
-        'Flask >= 1.0',
+        'Flask >= 1.0.3',
         'Flask-SQLAlchemy >= 1.0',
         'marshmallow >= 2.2.0',
         'SQLAlchemy >= 1.0.0',


### PR DESCRIPTION
I didn't realize v1.0.3 was cut. That explains why I had to make https://github.com/4Catalyzer/flask-resty/pull/261 to stay at 100% coverage.