### PR TITLE
chore: remove "system" commands in favor of tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
 before_script:
   - psql -c 'CREATE DATABASE travis_ci_test' -U postgres
 script:
-  - python setup.py test
+  - tox
 
 after_success:
   - codecov

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,4 @@
-import subprocess
-
-from setuptools import Command, setup
-
-# -----------------------------------------------------------------------------
-
-
-def system(command):
-    class SystemCommand(Command):
-        user_options = []
-
-        def initialize_options(self):
-            pass
-
-        def finalize_options(self):
-            pass
-
-        def run(self):
-            subprocess.check_call(command, shell=True)
-
-    return SystemCommand
-
-
-# -----------------------------------------------------------------------------
+from setuptools import setup
 
 setup(
     name="Flask-RESTy",
@@ -62,6 +39,5 @@ setup(
         "jwt": ("PyJWT >= 1.4.0", "cryptography >= 2.0.0"),
         "tests": ("coverage", "flake8", "psycopg2-binary", "pytest"),
     },
-    cmdclass={"test": system("tox")},
     entry_points={"pytest11": ("flask-resty = flask_resty.testing",)},
 )


### PR DESCRIPTION
Use tox for running tests and dev commands

* `tox`: run all test environments
* `tox -e lint`: runs `pre-commit run --all-files`
* `tox -e watch-docs`: builds docs in "watch" mode