### PR TITLE
test: fix tests

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -293,13 +293,7 @@ def test_error_invalid_value(client):
     assert_response(
         response,
         400,
-        [
-            {
-                "code": "invalid_filter",
-                "detail": "Must be at least 1.",
-                "source": {"parameter": "size_min"},
-            }
-        ],
+        [{"code": "invalid_filter", "source": {"parameter": "size_min"}}],
     )
 
 


### PR DESCRIPTION
Don't test against marshmallow's validation error message for `Range`, as it differs between marshmallow 2 and 3.