### PR TITLE
fix: Support for comma-encoded query params

### DIFF
--- a/flask_resty/fields.py
+++ b/flask_resty/fields.py
@@ -31,6 +31,7 @@ class RelatedItem(fields.Nested):
         # schema - in this context, they're actually not required.
         super(fields.Nested, self)._validate_missing(value)
 
+
 class DelimitedList(fields.List):
     """Same as `marshmallow.fields.List`, except can load from either a list or
     a delimited string (e.g. "foo,bar,baz"). Directly taken from webargs:
@@ -43,13 +44,15 @@ class DelimitedList(fields.List):
 
     delimiter = ","
 
-    def __init__(self, cls_or_instance, delimiter=None, as_string=False, **kwargs):
+    def __init__(
+        self, cls_or_instance, delimiter=None, as_string=False, **kwargs
+    ):
         self.delimiter = delimiter or self.delimiter
         self.as_string = as_string
-        super(DelimitedList, self).__init__(cls_or_instance, **kwargs)
+        super().__init__(cls_or_instance, **kwargs)
 
     def _serialize(self, value, attr, obj):
-        ret = super(DelimitedList, self)._serialize(value, attr, obj)
+        ret = super()._serialize(value, attr, obj)
         if self.as_string:
             return self.delimiter.join(format(each) for each in ret)
         return ret
@@ -63,4 +66,4 @@ class DelimitedList(fields.List):
             )
         except AttributeError:
             self.fail("invalid")
-        return super(DelimitedList, self)._deserialize(ret, attr, data, **kwargs)
+        return super()._deserialize(ret, attr, data, **kwargs)

--- a/flask_resty/fields.py
+++ b/flask_resty/fields.py
@@ -30,3 +30,37 @@ class RelatedItem(fields.Nested):
         # Do not display detailed error data on required fields in nested
         # schema - in this context, they're actually not required.
         super(fields.Nested, self)._validate_missing(value)
+
+class DelimitedList(fields.List):
+    """Same as `marshmallow.fields.List`, except can load from either a list or
+    a delimited string (e.g. "foo,bar,baz"). Directly taken from webargs:
+    https://github.com/marshmallow-code/webargs/blob/de061e037285fd08a42d73be95bc779f2a4e3c47/src/webargs/fields.py#L47
+
+    :param Field cls_or_instance: A field class or instance.
+    :param str delimiter: Delimiter between values.
+    :param bool as_string: Dump values to string.
+    """
+
+    delimiter = ","
+
+    def __init__(self, cls_or_instance, delimiter=None, as_string=False, **kwargs):
+        self.delimiter = delimiter or self.delimiter
+        self.as_string = as_string
+        super(DelimitedList, self).__init__(cls_or_instance, **kwargs)
+
+    def _serialize(self, value, attr, obj):
+        ret = super(DelimitedList, self)._serialize(value, attr, obj)
+        if self.as_string:
+            return self.delimiter.join(format(each) for each in ret)
+        return ret
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        try:
+            ret = (
+                value
+                if marshmallow.utils.is_iterable_but_not_string(value)
+                else value.split(self.delimiter)
+            )
+        except AttributeError:
+            self.fail("invalid")
+        return super(DelimitedList, self)._deserialize(ret, attr, data, **kwargs)

--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -400,12 +400,9 @@ class ApiView(MethodView):
                 # KeyError for args that aren't present.
                 continue
 
-            if not isinstance(field, fields.List):
-                value = args.get(field_name)
-            else:
-                tmp, value = args.getlist(field_name), []
-                for v in tmp:
-                    value.extend(v.split(","))
+            value = args.get(field_name)
+            if isinstance(field, fields.List) or "," in value:
+                value = value.split(",") if value else []
 
             data_raw[field_name] = value
 

--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -401,11 +401,12 @@ class ApiView(MethodView):
                 # KeyError for args that aren't present.
                 continue
 
-            value = args.get(field_name)
             if isinstance(field, fields.List) and not isinstance(
                 field, DelimitedList
             ):
                 value = args.getlist(field_name)
+            else:
+                value = args.get(field_name)
 
             data_raw[field_name] = value
 

--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -402,13 +402,10 @@ class ApiView(MethodView):
                 continue
 
             value = args.get(field_name)
-            if isinstance(field, fields.List) and not hasattr(field, "delimiter"):
+            if isinstance(field, fields.List) and not isinstance(
+                field, DelimitedList
+            ):
                 value = args.getlist(field_name)
-            elif isinstance(field, DelimitedList):
-                try:
-                    value = value.split(field.delimiter)
-                except AttributeError:
-                    self.fail('invalid')
 
             data_raw[field_name] = value
 

--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -400,9 +400,12 @@ class ApiView(MethodView):
                 # KeyError for args that aren't present.
                 continue
 
-            value = args.getlist(field_name)
-            if not isinstance(field, fields.List) and len(value) == 1:
-                value = value[0]
+            if not isinstance(field, fields.List):
+                value = args.get(field_name)
+            else:
+                tmp, value = args.getlist(field_name), []
+                for v in tmp:
+                    value.extend(v.split(","))
 
             data_raw[field_name] = value
 

--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -14,6 +14,7 @@ from .authorization import NoOpAuthorization
 from .compat import MA2, schema_dump, schema_load
 from .decorators import request_cached_property
 from .exceptions import ApiError
+from .fields import DelimitedList
 from .utils import iter_validation_errors, settable_property
 
 # -----------------------------------------------------------------------------
@@ -401,8 +402,13 @@ class ApiView(MethodView):
                 continue
 
             value = args.get(field_name)
-            if isinstance(field, fields.List) or "," in value:
-                value = value.split(",") if value else []
+            if isinstance(field, fields.List) and not hasattr(field, "delimiter"):
+                value = args.getlist(field_name)
+            elif isinstance(field, DelimitedList):
+                try:
+                    value = value.split(field.delimiter)
+                except AttributeError:
+                    self.fail('invalid')
 
             data_raw[field_name] = value
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -3,9 +3,8 @@ from marshmallow import Schema, fields
 
 from flask_resty import Api, ApiView
 from flask_resty.compat import MA2
-from flask_resty.testing import assert_response
-
 from flask_resty.fields import DelimitedList
+from flask_resty.testing import assert_response
 
 # -----------------------------------------------------------------------------
 
@@ -104,6 +103,7 @@ def test_get_names_one(client):
 def test_get_names_many(client):
     response = client.get("/names?name=foo&name=bar")
     assert_response(response, 200, ["foo", "bar"])
+
 
 def test_get_names_many_delimited(client):
     response = client.get("/names_delimited?name=foo,bar")

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -84,7 +84,7 @@ def test_get_names_one(client):
 
 
 def test_get_names_many(client):
-    response = client.get("/names?name=foo&name=bar")
+    response = client.get("/names?name=foo,bar")
     assert_response(response, 200, ["foo", "bar"])
 
 
@@ -126,7 +126,7 @@ def test_error_get_name_missing(client):
 
 
 def test_error_get_name_many(client):
-    response = client.get("/name?name=foo&name=bar")
+    response = client.get("/name?name=foo,bar")
     assert_response(
         response,
         422,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,8 +1,8 @@
 import pytest
 from marshmallow import Schema, ValidationError, fields
 
-from flask_resty import RelatedItem
 from flask_resty.compat import schema_dump, schema_load
+from flask_resty.fields import DelimitedList, RelatedItem
 
 # -----------------------------------------------------------------------------
 
@@ -35,6 +35,14 @@ def many_schema(related_schema_class):
 @pytest.fixture
 def error_messages():
     return RelatedItem(None).error_messages
+
+
+@pytest.fixture
+def delimited_list_schema():
+    class DelimitedListSchema(Schema):
+        ids = DelimitedList(fields.String, required=True)
+
+    return DelimitedListSchema()
 
 
 # -----------------------------------------------------------------------------
@@ -104,3 +112,18 @@ def test_error_load_many_type(many_schema, error_messages):
 
     errors = excinfo.value.messages
     assert errors == {"children": [error_messages["type"]]}
+
+
+# -----------------------------------------------------------------------------
+
+
+def test_load_delimited_list(delimited_list_schema):
+    data = schema_load(delimited_list_schema, {"ids": "1,2,3"})
+
+    assert data == {"ids": ["1", "2", "3"]}
+
+
+def test_dump_delimited_list(delimited_list_schema):
+    data = schema_dump(delimited_list_schema, {"ids": ["1", "2", "3"]})
+
+    assert data == {"ids": ["1", "2", "3"]}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -45,6 +45,14 @@ def delimited_list_schema():
     return DelimitedListSchema()
 
 
+@pytest.fixture
+def delimited_list_as_string_schema():
+    class DelimitedListAsStringSchema(Schema):
+        ids = DelimitedList(fields.String, as_string=True, required=True)
+
+    return DelimitedListAsStringSchema()
+
+
 # -----------------------------------------------------------------------------
 
 
@@ -127,3 +135,22 @@ def test_dump_delimited_list(delimited_list_schema):
     data = schema_dump(delimited_list_schema, {"ids": ["1", "2", "3"]})
 
     assert data == {"ids": ["1", "2", "3"]}
+
+
+def test_delimited_list_as_string(delimited_list_as_string_schema):
+    data = schema_dump(
+        delimited_list_as_string_schema, {"ids": ["1", "2", "3"]}
+    )
+
+    assert data == {"ids": "1,2,3"}
+
+
+# -----------------------------------------------------------------------------
+
+
+def test_error_delimited_list_validation_error(delimited_list_schema):
+    with pytest.raises(ValidationError) as excinfo:
+        schema_load(delimited_list_schema, {"ids": 1})
+
+    errors = excinfo.value.messages
+    assert errors == {"ids": ["Not a valid list."]}


### PR DESCRIPTION
For: https://github.com/4Catalyzer/flask-resty/issues/275
On Asana: https://app.asana.com/0/779493871603507/1126826827214118

This PR allows for comma-encoded query params, having multiple params with the same name (i.e. `foo=bar&foo=baz`), or even a mixture of both.

If we want to only support comma-encoded query params, we can change `request_args` to just get the value for the key and split the param value, and not use any of the features of MultiDicts.