### PR TITLE
fix: Log handled integrity errors as warnings

### DIFF
--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -961,7 +961,9 @@ class ModelView(ApiView):
             # a schema bug, so we emit an interal server error instead.
             return error
 
-        flask.current_app.logger.exception("handled integrity error")
+        flask.current_app.logger.warning(
+            "handled integrity error", exc_info=True
+        )
         return ApiError(409, {"code": "invalid_data.conflict"})
 
     def set_item_response_meta(self, item):

--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -962,7 +962,7 @@ class ModelView(ApiView):
             return error
 
         flask.current_app.logger.warning(
-            "handled integrity error", exc_info=True
+            "handled integrity error", exc_info=error
         )
         return ApiError(409, {"code": "invalid_data.conflict"})
 


### PR DESCRIPTION
They're not really errors. Not server errors, anyway.