### PR TITLE
Doc correct response for GenericModelView.destroy()

### DIFF
--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -1112,7 +1112,7 @@ class GenericModelView(ModelView):
         """Delete the item for the specified ID.
 
         :param id: The item ID.
-        :return: An HTTP 201 response.
+        :return: An HTTP 204 response.
         :rtype: :py:class:`flask.Response`
         """
         item = self.get_item_or_404(id)


### PR DESCRIPTION
Small doc fix: The docstring lists 201, but method returns 204 if successful.