### PR TITLE
feat: add shell command that auto-imports schemas and models

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -319,3 +319,54 @@ You can make requests using the `httpie <https://httpie.org/>`_ utility.
     }
 
 The naive datetimes in the response are only because the example uses SQLite. A real application would use a timezone-aware datetime column in the database, and would have a UTC offset in the response.
+
+Running the Shell
+-----------------
+
+Flask-RESTy includes an enhanced ``flask shell`` command that automatically imports all SQLAlchemy models and marshmallow schemas.
+It will also automatically use IPython, BPython, or ptpython if they are installed.
+
+::
+
+    $ FLASK_APP=example flask shell
+    3.8.5 (default, Jul 24 2020, 12:48:45)
+    [Clang 11.0.3 (clang-1103.0.32.62)]
+
+    _____ _           _         ____  _____ ____ _____
+    |  ___| | __ _ ___| | __    |  _ \| ____/ ___|_   _|   _
+    | |_  | |/ _` / __| |/ /____| |_) |  _| \___ \ | || | | |
+    |  _| | | (_| \__ \   <_____|  _ <| |___ ___) || || |_| |
+    |_|   |_|\__,_|___/_|\_\    |_| \_\_____|____/ |_| \__, |
+                                                        |___/
+    Flask app: example, Database: sqlite:///example.db
+
+    Flask:
+    app, g
+
+    Schemas:
+    AuthorSchema, BookSchema, Schema
+
+    Models:
+    Author, Book, commit, db, flush, rollback, session
+
+    In [1]: Author
+    Out[1]: example.models.Author
+
+    In [2]: AuthorSchema
+    Out[2]: example.schemas.AuthorSchema
+
+.. note::
+    Pass the ``--sqlalchemy-echo`` option to see database queries printed within your shell session.
+
+The following app configuration options are available for customizing ``flask shell``:
+
+- ``RESTY_SHELL_CONTEXT``: Dictionary of additional variables to include in the shell context.
+- ``RESTY_SHELL_LOGO``: Custom logo.
+- ``RESTY_SHELL_PROMPT``: Custom input prompt.
+- ``RESTY_SHELL_OUTPUT``: Custom output prompt.
+- ``RESTY_SHELL_CONTEXT_FORMAT``: Format to display shell context. May be ``'full'``, ``'short'``, or a function that receives the context dictionary as input and returns a string.
+- ``RESTY_SHELL_IPY_AUTORELOAD``: Whether to load and enable the IPython autoreload extension (must be using ``ipython`` shell).
+- ``RESTY_SHELL_IPY_EXTENSIONS``: List of IPython extension names to load (must be using ``ipython`` shell).
+- ``RESTY_SHELL_IPY_COLORS``: IPython color style.
+- ``RESTY_SHELL_IPY_HIGHLIGHTING_STYLE``: IPython code highlighting style.
+- ``RESTY_SHELL_PTPY_VI_MODE``: Enable vi mode (must be using ``ptpython`` shell).

--- a/flask_resty/shell.py
+++ b/flask_resty/shell.py
@@ -86,13 +86,15 @@ def format_section(title: str, section: dict) -> str:
 @click.option(
     "--shell", "-s", type=click.Choice(konch.SHELL_MAP.keys()), default="auto"
 )
+@click.option("--sqlalchemy-echo", is_flag=True)
 @with_appcontext
-def cli(shell: str):
+def cli(shell: str, sqlalchemy_echo: bool):
     """An improved Flask shell command."""
     from flask.globals import _app_ctx_stack
 
     app = _app_ctx_stack.top.app
     options = {key: app.config.get(key, DEFAULTS[key]) for key in DEFAULTS}
+    app.config["SQLALCHEMY_ECHO"] = sqlalchemy_echo
     base_context = {"app": app}
     flask_context = app.make_shell_context()
     schema_context = get_schema_context()

--- a/flask_resty/shell.py
+++ b/flask_resty/shell.py
@@ -35,7 +35,7 @@ DEFAULTS = dict(
 def get_models_context(app: flask.Flask) -> dict:
     try:
         db = app.extensions["sqlalchemy"].db
-    except KeyError:
+    except KeyError:  # pragma: no cover
         return {}
 
     ret = {
@@ -54,17 +54,10 @@ def get_models_context(app: flask.Flask) -> dict:
     return ret
 
 
-def get_flask_imports():
-    ret = {}
-    for name in [e for e in dir(flask) if not e.startswith("_")]:
-        ret[name] = getattr(flask, name)
-    return ret
-
-
 def get_schema_context() -> dict:
     try:
         from marshmallow import class_registry
-    except ImportError:
+    except ImportError:  # pragma: no cover
         return {}
     return {
         schema_name: classes[0]
@@ -87,7 +80,9 @@ def format_section(title: str, section: dict) -> str:
     return f"\n{formatted_title}\n{formatted_section}"
 
 
-@click.command(help="Run an interactive shell.")
+@click.command(
+    help="Run an interactive shell with models and schemas automatically imported."
+)
 @click.option(
     "--shell", "-s", type=click.Choice(konch.SHELL_MAP.keys()), default="auto"
 )
@@ -155,7 +150,7 @@ def cli(shell: str):
             ],
         )
     )
-    if Path(".konchrc.local").exists():
+    if Path(".konchrc.local").exists():  # pragma: no cover
         konch.use_file(".konchrc.local", trust=True)
 
     konch.start(**config)

--- a/flask_resty/shell.py
+++ b/flask_resty/shell.py
@@ -1,0 +1,161 @@
+"""Entry point for the ``shell`` Flask-RESTy CLI commmand."""
+# Code adapted from flask-konch
+from pathlib import Path
+
+import click
+import flask
+import konch
+from flask.cli import with_appcontext
+
+LOGO = r"""
+  _____ _           _         ____  _____ ____ _____
+ |  ___| | __ _ ___| | __    |  _ \| ____/ ___|_   _|   _
+ | |_  | |/ _` / __| |/ /____| |_) |  _| \___ \ | || | | |
+ |  _| | | (_| \__ \   <_____|  _ <| |___ ___) || || |_| |
+ |_|   |_|\__,_|___/_|\_\    |_| \_\_____|____/ |_| \__, |
+                                                    |___/
+""".strip(
+    "\n"
+)
+
+DEFAULTS = dict(
+    RESTY_SHELL_CONTEXT={},
+    RESTY_SHELL_LOGO=LOGO,
+    RESTY_SHELL_PROMPT=None,
+    RESTY_SHELL_OUTPUT=None,
+    RESTY_SHELL_CONTEXT_FORMAT=None,
+    RESTY_SHELL_IPY_AUTORELOAD=False,
+    RESTY_SHELL_IPY_EXTENSIONS=None,
+    RESTY_SHELL_IPY_COLORS="linux",
+    RESTY_SHELL_IPY_HIGHLIGHTING_STYLE=None,
+    RESTY_SHELL_PTPY_VI_MODE=False,
+)
+
+
+def get_models_context(app: flask.Flask) -> dict:
+    try:
+        db = app.extensions["sqlalchemy"].db
+    except KeyError:
+        return {}
+
+    ret = {
+        "db": db,
+        "session": db.session,
+        "commit": db.session.commit,
+        "rollback": db.session.rollback,
+        "flush": db.session.flush,
+    }
+    models = {
+        name: cls
+        for name, cls in db.Model._decl_class_registry.items()
+        if isinstance(cls, type) and issubclass(cls, db.Model)
+    }
+    ret.update(models)
+    return ret
+
+
+def get_flask_imports():
+    ret = {}
+    for name in [e for e in dir(flask) if not e.startswith("_")]:
+        ret[name] = getattr(flask, name)
+    return ret
+
+
+def get_schema_context() -> dict:
+    try:
+        from marshmallow import class_registry
+    except ImportError:
+        return {}
+    return {
+        schema_name: classes[0]
+        for schema_name, classes in class_registry._registry.items()
+        if "." not in schema_name
+    }
+
+
+def get_banner(app: flask.Flask, logo=LOGO) -> str:
+    info = f"Flask app: {click.style(app.name, fg='green')}"
+    if "SQLALCHEMY_DATABASE_URI" in app.config:
+        database_uri = app.config["SQLALCHEMY_DATABASE_URI"]
+        info += f", Database: {click.style(database_uri, fg='green')}"
+    return f"{logo}\n{info}"
+
+
+def format_section(title: str, section: dict) -> str:
+    formatted_section = ", ".join(sorted(section.keys(), key=str.lower))
+    formatted_title = click.style(f"{title}:", bold=True)
+    return f"\n{formatted_title}\n{formatted_section}"
+
+
+@click.command(help="Run an interactive shell.")
+@click.option(
+    "--shell", "-s", type=click.Choice(konch.SHELL_MAP.keys()), default="auto"
+)
+@with_appcontext
+def cli(shell: str):
+    """An improved Flask shell command."""
+    from flask.globals import _app_ctx_stack
+
+    app = _app_ctx_stack.top.app
+    options = {key: app.config.get(key, DEFAULTS[key]) for key in DEFAULTS}
+    base_context = {"app": app}
+    flask_context = app.make_shell_context()
+    schema_context = get_schema_context()
+    context = dict(base_context)
+    model_context = get_models_context(app)
+    settings_context = options["RESTY_SHELL_CONTEXT"]
+
+    def context_formatter(full_context: dict):
+        """Flask-RESTy-specific context formatter. Groups objects
+        into sections with a bold header for each.
+        """
+        sections = [("Flask", flask_context)]
+        if schema_context:
+            sections.append(("Schemas", schema_context))
+        if model_context:
+            sections.append(("Models", model_context))
+
+        additional_context_keys = (
+            full_context.keys()
+            - flask_context.keys()
+            - schema_context.keys()
+            - model_context.keys()
+        )
+        additional_context = {
+            key: full_context[key] for key in additional_context_keys
+        }
+        if additional_context:
+            sections.append(("Additional", additional_context))
+        return "\n".join([format_section(*section) for section in sections])
+
+    context = {
+        **flask_context,
+        **schema_context,
+        **model_context,
+        **settings_context,
+    }
+    context_format = options["RESTY_SHELL_CONTEXT_FORMAT"] or context_formatter
+    banner = get_banner(app, logo=options["RESTY_SHELL_LOGO"])
+    # Use singleton _cfg to allow overrides in .konchrc.local
+    config = konch._cfg
+    config.update(
+        dict(
+            context=context,
+            context_format=context_format,
+            banner=banner,
+            shell=shell,
+            prompt=options["RESTY_SHELL_PROMPT"],
+            output=options["RESTY_SHELL_OUTPUT"],
+            ptpy_vi_mode=options["RESTY_SHELL_PTPY_VI_MODE"],
+            ipy_extensions=options["RESTY_SHELL_IPY_EXTENSIONS"],
+            ipy_autoreload=options["RESTY_SHELL_IPY_AUTORELOAD"],
+            ipy_colors=options["RESTY_SHELL_IPY_COLORS"],
+            ipy_highlighting_style=options[
+                "RESTY_SHELL_IPY_HIGHLIGHTING_STYLE"
+            ],
+        )
+    )
+    if Path(".konchrc.local").exists():
+        konch.use_file(".konchrc.local", trust=True)
+
+    konch.start(**config)

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,15 @@ setup(
         "marshmallow>=3.0.0",
         "SQLAlchemy>=1.0.0",
         "Werkzeug>=0.11",
+        "konch>=4.0",
     ),
     extras_require={
         "docs": ("sphinx", "pallets-sphinx-themes"),
         "jwt": ("PyJWT>=1.4.0", "cryptography>=2.0.0"),
         "tests": ("coverage", "psycopg2-binary", "pytest"),
     },
-    entry_points={"pytest11": ("flask-resty = flask_resty.testing",)},
+    entry_points={
+        "pytest11": ("flask-resty = flask_resty.testing",),
+        "flask.commands": ("shell = flask_resty.shell:cli",),
+    },
 )

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,128 @@
+import pytest
+from click.testing import CliRunner
+from flask.cli import ScriptInfo
+from marshmallow import Schema, fields
+from sqlalchemy import Column, Integer, String
+
+from flask_resty.shell import cli
+
+
+@pytest.fixture
+def models(db):
+    class Widget(db.Model):
+        __tablename__ = "widgets"
+
+        id = Column(Integer, primary_key=True)
+        name = Column(String, nullable=False)
+        description = Column(String)
+
+    db.create_all()
+
+    yield {"widget": Widget}
+
+    db.drop_all()
+
+
+@pytest.fixture
+def schemas():
+    class WidgetSchema(Schema):
+        id = fields.Integer(as_string=True)
+        name = fields.String(required=True)
+        description = fields.String()
+
+    return {"widget": WidgetSchema()}
+
+
+@pytest.fixture
+def make_app(app, models, schemas):
+    def maker(config):
+        app.config.update(config)
+
+        # Register custom shell context
+        def shell_context_processor():
+            return {
+                "shellctx": "shellctx-value",
+                "shellctx_overriden_by_context": "not-overridden",
+            }
+
+        app.shell_context_processor(shell_context_processor)
+
+        return app
+
+    return maker
+
+
+@pytest.fixture(scope="session")
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def run_command(runner, make_app):
+    def run(args=tuple(), *, config=None, **kwargs):
+        app = make_app(config=config or {})
+        obj = ScriptInfo(create_app=lambda info: app)
+        # Always use default python shell
+        return runner.invoke(cli, ("--shell", "py", *args), obj=obj, **kwargs)
+
+    return run
+
+
+# -----------------------------------------------------------------------------
+
+
+def test_no_args(run_command):
+    result = run_command()
+    assert result.exit_code == 0
+    # Flask imports
+    assert "Flask:" in result.output
+    assert "app, g" in result.output
+    # Models
+    assert "Models:" in result.output
+    # Schemas
+    assert "Schemas:" in result.output
+    assert "WidgetSchema" in result.output
+
+
+def test_additional_context(run_command):
+    result = run_command(
+        config={
+            "RESTY_SHELL_CONTEXT": {"foo": "foo-value", "bar": "bar-value"}
+        },
+        input="bar",
+    )
+    assert "Additional:" in result.output
+    assert "bar, foo" in result.output
+    assert ">>> 'bar-value'" in result.output
+
+
+def test_flask_shell_context_processors(run_command):
+    result = run_command(
+        config={
+            "RESTY_SHELL_CONTEXT": {
+                "shellctx_overriden_by_context": "overridden-in-settings"
+            }
+        },
+        input="shellctx\nshellctx_overriden_by_context",
+    )
+    assert "Flask:" in result.output
+    assert ">>> 'shellctx-value'" in result.output
+    assert ">>> 'overridden-in-settings'" in result.output
+
+
+def test_logo(run_command):
+    result = run_command(config={"RESTY_SHELL_LOGO": "foobarbaz"})
+    assert "foobarbaz" in result.output
+
+
+def test_prompt(run_command):
+    result = run_command(config={"RESTY_SHELL_PROMPT": "foo>>>>"})
+    assert "foo>>>>" in result.output
+
+
+def test_context_format(run_command):
+    def format_ctx(ctx):
+        return "foobarbaz"
+
+    result = run_command(config={"RESTY_SHELL_CONTEXT_FORMAT": format_ctx})
+    assert "foobarbaz" in result.output

--- a/tox.ini
+++ b/tox.ini
@@ -32,4 +32,4 @@ commands = sphinx-build docs/ docs/_build {posargs}
 deps =
   sphinx-autobuild
 extras = docs
-commands = sphinx-autobuild --open-browser docs/ docs/_build {posargs} -z flask_resty -s 2
+commands = sphinx-autobuild --open-browser docs/ docs/_build {posargs} --watch flask_resty --delay 2


### PR DESCRIPTION
Add an enhanced `flask shell` command that automatically imports SQLAlchemy models and marshmallow schemas.

Much of this is adapted from [flask-konch](https://github.com/sloria/flask-konch/blob/master/flask_konch/cli.py) and private code that we have in Butterfly.

![Image 2020-09-25 at 4 33 41 PM](https://user-images.githubusercontent.com/2379650/94313544-e7379b80-ff4c-11ea-8e4f-651af467f97a.png)