### PR TITLE
pin jwt below 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 EXTRAS_REQUIRE = {
     "docs": ("sphinx", "pallets-sphinx-themes"),
-    "jwt": ("PyJWT>=1.4.0", "cryptography>=2.0.0"),
+    "jwt": ("PyJWT>=1.4.0,<2.0.0", "cryptography>=2.0.0"),
     "tests": ("coverage", "psycopg2-binary", "pytest"),
 }
 EXTRAS_REQUIRE["dev"] = (


### PR DESCRIPTION
Good news is that pyjwt 3 added some nice abstractions for working with jwk and jwk sets. Bad news is that adding a compatibility layer for making it work with 2 and 3 is not straightforward. we can eventually move to pyjwt 3 but I don't think we need to rush