### PR TITLE
build: fix publishing in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ name: CI
 on:
   push:
     branches: ["master"]
+    tags:
+      - "*"
   pull_request:
     branches: ["master"]
   workflow_dispatch:


### PR DESCRIPTION
The publish step currently isn't running because tags aren't triggering builds