### PR TITLE
build: test against Python 3.6 and 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
     name: "Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
     env:
-      USING_COVERAGE: "3.8"
+      USING_COVERAGE: "3.10"
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.10"]
 
     steps:
       - uses: "actions/checkout@v2"
@@ -41,7 +41,7 @@ jobs:
       # parsing errors in older versions for modern code.
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: "Combine coverage"
         run: |
@@ -63,7 +63,7 @@ jobs:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: "Install build, check-wheel-content, and twine"
         run: "python -m pip install build twine check-wheel-contents"
@@ -97,7 +97,7 @@ jobs:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: "Install in dev mode"
         run: "python -m pip install -e .[dev]"
       - name: "Import package"


### PR DESCRIPTION
Tests against Python 3.6 and 3.10 and CI.

I don't think we get much value out of testing the intermediate Python versions, and we might as well save some CPU cycles.

TODO after merging: add Python 3.10 to list of required builds.