### PR TITLE
feat: add page info to connection meta

### DIFF
--- a/flask_resty/pagination.py
+++ b/flask_resty/pagination.py
@@ -564,17 +564,51 @@ class RelayCursorPagination(CursorPaginationBase):
     https://facebook.github.io/relay/graphql/connections.htm.
     """
 
+    page_info_arg = "page_info"
+
+    def __init__(self, *args, default_include_page_info=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._default_include_page_info = default_include_page_info
+
+    def get_page_info(self, query, view, field_orderings, cursor):
+        include = flask.request.args.get(
+            self.page_info_arg, self._default_include_page_info
+        )
+
+        if not bool(include):
+            return {}
+
+        total = query.count()
+
+        index = 0
+        if cursor:
+            filter_clause = self.get_filter(
+                view,
+                tuple((field, not order) for field, order in field_orderings),
+                cursor,
+            )
+            index = query.filter(filter_clause).count()
+
+        # in the reversed case, both the order by and sort of inverted.
+        # so in practice this gives us a reverse index, e.g. distance from
+        # the end of the list. We normalize it back by subtracting from the total
+        if self.reversed:
+            index = max(total - index - 1, 0)
+
+        return {"index": index, "total": total}
+
     def get_page(self, query, view):
         field_orderings = self.get_field_orderings(view)
 
         cursor_in = self.get_request_cursor(view, field_orderings)
 
+        page_query = query
         if cursor_in is not None:
-            query = query.filter(
+            page_query = page_query.filter(
                 self.get_filter(view, field_orderings, cursor_in)
             )
 
-        items = super().get_page(query, view)
+        items = super().get_page(page_query, view)
 
         if self.reversed:
             items.reverse()
@@ -582,7 +616,9 @@ class RelayCursorPagination(CursorPaginationBase):
         # Relay expects a cursor for each item.
         cursors_out = self.make_cursors(items, view, field_orderings)
 
-        meta.update_response_meta({"cursors": cursors_out})
+        page_info = self.get_page_info(query, view, field_orderings, cursor_in)
+
+        meta.update_response_meta({"cursors": cursors_out, **page_info})
 
         return items
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -325,7 +325,7 @@ def test_relay_cursor_sorted(client, data):
 
 
 def test_relay_cursor_sorted_default(client, data):
-    response = client.get("/relay_cursor_widgets?sort=size")
+    response = client.get("/relay_cursor_widgets?sort=size&page_info=true")
 
     assert_response(
         response, 200, [{"id": "1", "size": 1}, {"id": "4", "size": 1}]
@@ -333,6 +333,8 @@ def test_relay_cursor_sorted_default(client, data):
     assert get_meta(response) == {
         "has_next_page": True,
         "cursors": ["MQ.MQ", "MQ.NA"],
+        "index": 0,
+        "total": 6,
     }
 
 
@@ -349,7 +351,9 @@ def test_relay_cursor_sorted_redundant(client, data):
 
 
 def test_relay_cursor_sorted_inverse(client, data):
-    response = client.get("/relay_cursor_widgets?sort=-size&cursor=Mg.NQ")
+    response = client.get(
+        "/relay_cursor_widgets?sort=-size&cursor=Mg.NQ&page_info=true"  # widget 5 size=2
+    )
 
     assert_response(
         response, 200, [{"id": "2", "size": 2}, {"id": "4", "size": 1}]
@@ -357,6 +361,8 @@ def test_relay_cursor_sorted_inverse(client, data):
     assert get_meta(response) == {
         "has_next_page": True,
         "cursors": ["Mg.Mg", "MQ.NA"],
+        "index": 2,
+        "total": 6,
     }
 
 
@@ -400,11 +406,11 @@ def test_relay_reverse_cursor(client, add_widgets):
 def test_relay_reverse_cursor_inverse(client, add_widgets):
     add_widgets(
         (
-            {"id": "1", "size": 2},
-            {"id": "2", "size": 2},
-            {"id": "3", "size": 1},
             {"id": "4", "size": 5},
             {"id": "5", "size": 3},
+            {"id": "2", "size": 2},
+            {"id": "1", "size": 2},
+            {"id": "3", "size": 1},
         )
     )
 
@@ -414,8 +420,21 @@ def test_relay_reverse_cursor_inverse(client, add_widgets):
         {"id": "2", "size": 2},
     ]
 
-    resp = client.get("/relay_cursor_widgets?sort=-size&limit=3")
+    resp = client.get(
+        "/relay_cursor_widgets?sort=-size&limit=3&page_info=true"
+    )
     assert_response(resp, 200, first_three_items)
+
+    assert get_meta(resp) == {
+        "has_next_page": True,
+        "cursors": [
+            encode_cursor((5, "4")),
+            encode_cursor((3, "5")),
+            encode_cursor((2, "2")),
+        ],
+        "index": 0,
+        "total": 5,
+    }
 
     # this should be the next item in the list above
     before = encode_cursor((2, "1"))
@@ -424,13 +443,17 @@ def test_relay_reverse_cursor_inverse(client, add_widgets):
     )
     assert_response(resp, 200, first_three_items)
 
-    resp = client.get(f"/relay_cursor_widgets?sort=-size&before={before}")
+    resp = client.get(
+        f"/relay_cursor_widgets?sort=-size&before={before}&page_info=true"
+    )
 
     assert_response(resp, 200, first_three_items[1:])
 
     assert get_meta(resp) == {
         "has_next_page": True,
         "cursors": [encode_cursor((3, "5")), encode_cursor((2, "2"))],
+        "index": 3,
+        "total": 5,
     }
 
 
@@ -487,7 +510,7 @@ def test_relay_cursor_no_validate(app, client, data):
     assert_response(response, 422)
 
     response = client.get(
-        "/relay_cursor_no_validate_widgets?sort=size&cursor=Mg.Mg"
+        "/relay_cursor_no_validate_widgets?sort=size&cursor=Mg.Mg"  # Widget 2.2
     )
     assert_response(
         response, 200, [{"id": "5", "size": 2}, {"id": "3", "size": 3}]

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -86,12 +86,17 @@ def routes(app, models, schemas):
 
     class RelayCursorListView(WidgetListViewBase):
         sorting = Sorting("id", "size", "is_cool")
-        pagination = RelayCursorPagination(2)
+        pagination = RelayCursorPagination(
+            2,
+            page_info_arg="page_info",
+        )
 
     class RelayCursorNoValidateListView(RelayCursorListView):
         schema = schemas["widget_validate"]
 
-        pagination = RelayCursorPagination(2, validate_values=False)
+        pagination = RelayCursorPagination(
+            2, page_info_arg="page_info", validate_values=False
+        )
 
     api = Api(app)
     api.add_resource("/max_limit_widgets", MaxLimitWidgetListView)


### PR DESCRIPTION
Absolutely not sure this is the right way to do this. Basically we need info about totals and cursor index in order to provide paging UI that looks like 
![image](https://user-images.githubusercontent.com/339286/145273918-7a403e48-db16-4d64-a68b-aa4c0348a044.png)

I've no sense on the most efficient way to return this info tho. should we remove the selected columns from the query? is that safe? is it ok to rely on what SQL Alchemy generates here? should we provide hooks to customize it?