### PR TITLE
feat: proper two way cursor pagination

### DIFF
--- a/flask_resty/pagination.py
+++ b/flask_resty/pagination.py
@@ -329,7 +329,7 @@ class CursorPaginationBase(LimitPagination):
 
         # Ambigious cases where limits are provided but not cursors
 
-        # Therre may be two explicit limit args provided, default to "first"
+        # Thrre may be two explicit limit args provided, default to "first"
         # in keeping with the cursor logic
         elif self.first_arg in flask.request.args:
             reversed = False

--- a/flask_resty/pagination.py
+++ b/flask_resty/pagination.py
@@ -303,14 +303,14 @@ class CursorPaginationBase(LimitPagination):
         return (None, None)
 
     # There are a number of different cases that this covers in order to be backwards compatible with
-    def get_cursor_info(self):
+    def get_cursor_info(self) -> CursorInfo:
         cursor = None
         cursor_arg = None
 
         limit = None
         limit_arg = None
 
-        # Unambigious cases where a cursor is provided.
+        # Unambiguous cases where a cursor is provided.
         # legacy "cursor_arg" cases always map to after/first
         if (
             self.after_arg in flask.request.args
@@ -327,9 +327,9 @@ class CursorPaginationBase(LimitPagination):
             cursor, cursor_arg = self.try_get_arg(self.before_arg)
             limit, limit_arg = self.try_get_arg(self.last_arg, self.limit_arg)
 
-        # Ambigious cases where limits are provided but not cursors
+        # Ambiguous cases where limits are provided but not cursors
 
-        # Thrre may be two explicit limit args provided, default to "first"
+        # There may be two explicit limit args provided, default to "first"
         # in keeping with the cursor logic
         elif self.first_arg in flask.request.args:
             reversed = False

--- a/flask_resty/pagination.py
+++ b/flask_resty/pagination.py
@@ -1,5 +1,6 @@
 import base64
-from typing import Any, List, Tuple
+from dataclasses import dataclass
+from typing import Any, List, Tuple, Union
 
 import flask
 import sqlalchemy as sa
@@ -248,6 +249,17 @@ class PagePagination(LimitOffsetPagination):
 Cursor = Tuple[Any, ...]
 
 
+@dataclass
+class CursorInfo:
+    reversed: bool
+
+    cursor: Union[str, None]
+    cursor_arg: Union[str, None]
+
+    limit: Union[str, None]
+    limit_arg: Union[str, None]
+
+
 class CursorPaginationBase(LimitPagination):
     """The base class for pagination schemes that use cursors.
 
@@ -268,20 +280,83 @@ class CursorPaginationBase(LimitPagination):
 
     #: The name of the query parameter to inspect for the cursor value.
     cursor_arg = "cursor"
+    limit_arg = "limit"
 
     #: the name of the query parameter to inspect for explicit forward pagination
     after_arg = "after"
+    first_arg = "first"
 
     #: the name of the query parameter to inspect for explicit backward pagination
     before_arg = "before"
+    last_arg = "last"
 
     def __init__(self, *args, validate_values=True, **kwargs):
         super().__init__(*args, **kwargs)
         self._validate_values = validate_values
 
+    def try_get_arg(self, *args):
+        for arg in args:
+            value = flask.request.args.get(arg)
+            if value is not None:
+                return (value, arg)
+
+        return (None, None)
+
+    # There are a number of different cases that this covers in order to be backwards compatible with
+    def get_cursor_info(self):
+        cursor = None
+        cursor_arg = None
+
+        limit = None
+        limit_arg = None
+
+        # Unambigious cases where a cursor is provided.
+        # legacy "cursor_arg" cases always map to after/first
+        if (
+            self.after_arg in flask.request.args
+            or self.cursor_arg in flask.request.args
+        ):
+            reversed = False
+            cursor, cursor_arg = self.try_get_arg(
+                self.after_arg, self.cursor_arg
+            )
+            limit, limit_arg = self.try_get_arg(self.first_arg, self.limit_arg)
+
+        elif self.before_arg in flask.request.args:
+            reversed = True
+            cursor, cursor_arg = self.try_get_arg(self.before_arg)
+            limit, limit_arg = self.try_get_arg(self.last_arg, self.limit_arg)
+
+        # Ambigious cases where limits are provided but not cursors
+
+        # Therre may be two explicit limit args provided, default to "first"
+        # in keeping with the cursor logic
+        elif self.first_arg in flask.request.args:
+            reversed = False
+            limit, limit_arg = self.try_get_arg(self.first_arg)
+
+        elif self.last_arg in flask.request.args:
+            reversed = True
+            limit, limit_arg = self.try_get_arg(self.last_arg)
+
+        # other wise fall back on limit
+        else:
+            reversed = False
+            limit, limit_arg = self.try_get_arg(self.limit_arg)
+
+        return CursorInfo(reversed, cursor, cursor_arg, limit, limit_arg)
+
+    def get_limit(self):
+        cursor_info = self.get_cursor_info()
+
+        try:
+            return self.parse_limit(cursor_info.limit)
+        except ApiError as e:
+            raise e.update({"source": {"parameter": cursor_info.limit_arg}})
+
     @property
     def reversed(self):
-        return self.get_raw_request_cursor()[1] == self.before_arg
+        return self.get_cursor_info().reversed
 
     def adjust_sort_ordering(
         self, view: ModelView, field_orderings
@@ -344,16 +419,6 @@ class CursorPaginationBase(LimitPagination):
 
         return field_ordering
 
-    def get_raw_request_cursor(self):
-        cursor_args = [self.cursor_arg, self.after_arg, self.before_arg]
-
-        for arg in cursor_args:
-            cursor = flask.request.args.get(arg)
-            if cursor is not None:
-                return (cursor, arg)
-
-        return (None, "")
-
     def get_request_cursor(self, view, field_orderings):
         """Get the cursor value specified in the request.
 
@@ -373,15 +438,15 @@ class CursorPaginationBase(LimitPagination):
             `cursor_arg`.
         """
 
-        cursor, arg = self.get_raw_request_cursor()
+        cursor_info = self.get_cursor_info()
 
-        if cursor is None:
+        if cursor_info.cursor is None:
             return None
 
         try:
-            return self.parse_cursor(view, cursor, field_orderings)
+            return self.parse_cursor(view, cursor_info.cursor, field_orderings)
         except ApiError as e:
-            raise e.update({"source": {"parameter": arg}})
+            raise e.update({"source": {"parameter": cursor_info.cursor_arg}})
 
     def parse_cursor(
         self,

--- a/flask_resty/pagination.py
+++ b/flask_resty/pagination.py
@@ -339,7 +339,7 @@ class CursorPaginationBase(LimitPagination):
             reversed = True
             limit, limit_arg = self.try_get_arg(self.last_arg)
 
-        # other wise fall back on limit
+        # otherwise fall back on limit
         else:
             reversed = False
             limit, limit_arg = self.try_get_arg(self.limit_arg)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -632,7 +632,7 @@ def test_error_invalid_relay_cursor_field(client, data):
         ),
         (
             {"cursor": "foo", "last": 30},
-            CursorInfo(False, "foo", "cursor", None, None),
+            CursorInfo(True, None, None, 30, "last"),
         ),
         (
             {"after": "foo"},
@@ -640,7 +640,7 @@ def test_error_invalid_relay_cursor_field(client, data):
         ),
         (
             {"after": "foo", "limit": 30},
-            CursorInfo(False, "foo", "after", 30, "limit"),
+            CursorInfo(False, "foo", "after", None, None),
         ),
         (
             {"after": "foo", "first": 30},
@@ -660,11 +660,11 @@ def test_error_invalid_relay_cursor_field(client, data):
         ),
         (
             {"cursor": "foo", "first": 30},
-            CursorInfo(False, "foo", "cursor", 30, "first"),
+            CursorInfo(False, None, None, 30, "first"),
         ),
         (
             {"before": "foo", "limit": 30},
-            CursorInfo(True, "foo", "before", 30, "limit"),
+            CursorInfo(True, "foo", "before", None, None),
         ),
         (
             {"before": "foo", "last": 30},


### PR DESCRIPTION
I regret my earlier choices, and have gone ahead and added fully distinct limit and cursor arguments for forward and backwards pagination. I considered just saying "F it" and not making it backwards compatible however that would actually make it hard for use to consume this, if not coupled with graphql updates