### PR TITLE
fix: get the schema deserialized view args if available

### DIFF
--- a/flask_resty/filtering.py
+++ b/flask_resty/filtering.py
@@ -351,7 +351,7 @@ class Filtering:
         :return: The filtered query
         :rtype: :py:class:`sqlalchemy.orm.query.Query`
         """
-        args = flask.request.args
+        args = view.request_args if view.args_schema else flask.request.args
 
         for arg_name, arg_filter in self._arg_filters.items():
             try:


### PR DESCRIPTION
Does this make sense? It seems like the args_schema deserialized view args should be used, if available