### PR TITLE
fix: order of add item authorization check seems incorrect

### DIFF
--- a/flask_resty/view.py
+++ b/flask_resty/view.py
@@ -784,8 +784,8 @@ class ModelView(ApiView):
 
         :param object item: The item to add.
         """
-        self.add_item_raw(item)
         self.authorization.authorize_save_item(item)
+        self.add_item_raw(item)
 
     def add_item_raw(self, item):
         """As with `add_item`, but without the authorization check.


### PR DESCRIPTION
The order of the call to authorize whether an item can be added seems unusual. Opening for discussion.